### PR TITLE
Resolved: Issue #9 by adding a private constructor to the API Constants Utility class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
     id 'de.mannodermaus.android-junit5'
 }
 
+
 def getVersionCode = { ->
     try {
         def stdout = new ByteArrayOutputStream()

--- a/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/APIConstants.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/APIConstants.java
@@ -6,6 +6,10 @@ import java.util.ArrayList;
 
 public class APIConstants {
 
+    private APIConstants(){
+        // Private constructor to prevent instantiation
+    }
+
     public static final double LAT_LON_FACTOR = 1E6;
 
     // NOTE: Needs to be used in AndroidManifest.xml!


### PR DESCRIPTION
**Description of the Issue**
Missing private constructor in a Utility class. Utility classes should not have public constructors.

**Link to the the issue**
[Issue 9](https://github.com/rilling/OSMDashboardConcordia/issues/9)