### PR TITLE
Implement the AVERAGE_SPEED_KM_H element to display the average speed. 

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/StatisticElement.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/StatisticElement.java
@@ -70,6 +70,13 @@ public enum StatisticElement {
         public String getText(Context context, TrackStatistics statistics) {
             return StringUtils.formatAltitudeChangeInFeet(context, statistics.getElevationGainMeter());
         }
+    },
+    AVERAGE_SPEED_KM_H(R.string.average_speed_km_h) {
+        @Override
+        public String getText(Context context, TrackStatistics statistics) {
+            double avgSpeedMetersPerSecond = statistics.getAvgSpeedMeterPerSecond();
+            return String.valueOf(avgSpeedMetersPerSecond);
+        }
     };
 
     private final int labelResId;

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -106,5 +106,5 @@
     <string name="track_color_mode_uni">Unicolor</string>
     <string name="track_color_mode_by_track">Color by track</string>
     <string name="track_color_mode_by_speed">Color by speed</string>
-
+    <string name="average_speed_km_h">Average speed (km/h)</string>
 </resources>


### PR DESCRIPTION
Resolves issue #95 
Implemented the AVERAGE_SPEED_KM_H element to display the average speed in the file StatisticElement.java 


    AVERAGE_SPEED_KM_H(R.string.average_speed_km_h) {
        @Override
        public String getText(Context context, TrackStatistics statistics) {
            double avgSpeedMetersPerSecond = statistics.getAvgSpeedMeterPerSecond();
            return String.valueOf(avgSpeedMetersPerSecond);

Taking the Strings from the String.utils provided.