### PR TITLE
solved issue #97, Added Average speed to Preferences utils

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/PreferencesUtils.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/PreferencesUtils.java
@@ -53,7 +53,8 @@ public class PreferencesUtils {
                         StatisticElement.DISTANCE_MI.name(),
                         StatisticElement.PACE_MIN_MI.name(),
                         StatisticElement.SPEED_MI_H.name(),
-                        StatisticElement.ELEVATION_GAIN_FEET.name());
+                        StatisticElement.ELEVATION_GAIN_FEET.name(),
+                        StatisticElement.AVERAGE_SPEED_KM_H.name());
             }
 
             setStringSet(R.string.STATISTIC_ELEMENTS, Unit_Statistic_Elements);

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -107,4 +107,5 @@
     <string name="track_color_mode_by_track">Color by track</string>
     <string name="track_color_mode_by_speed">Color by speed</string>
     <string name="average_speed_km_h">Average speed (km/h)</string>
+    <string name="average_speed_mi_h">Average speed (mi/h)</string> 
 </resources>


### PR DESCRIPTION
Resolves issue https://github.com/rilling/OSMDashboardConcordia/issues/97
Implemented the AVERAGE_SPEED_KM_H element to display the average speed in the file StatisticElement.java


![Screenshot 2023-11-25 233007](https://github.com/rilling/OSMDashboardConcordia/assets/126364332/c21fdff7-3117-41da-9ad0-771c59243eec)

StatisticElement.AVERAGE_SPEED_KM_H.name()); retrieves the string representation of the enum constant AVERAGE_SPEED_KM_H from the StatisticElement enum, and it is likely used to include this statistical element in a set of unit statistic elements for non-US locales within the OpenTracks OSM plugin preferences.