### PR TITLE
Resolves Issue #100- Formatted Mi/h and Km/h accordingly

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/PreferencesUtils.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/PreferencesUtils.java
@@ -36,28 +36,27 @@ public class PreferencesUtils {
         mRes = context.getResources();
 
 
-            if(mRes.getConfiguration().getLocales().get(0).getCountry().equals("US"))
-            {
-                Unit_Statistic_Elements = Set.of(
-                        StatisticElement.CATEGORY.name(),
-                        StatisticElement.MOVING_TIME.name(),
-                        StatisticElement.DISTANCE_KM.name(),
-                        StatisticElement.PACE_MIN_KM.name(),
-                        StatisticElement.SPEED_KM_H.name(),
-                        StatisticElement.ELEVATION_GAIN_METER.name());
-            }
-            else {
-                Unit_Statistic_Elements = Set.of(
-                        StatisticElement.CATEGORY.name(),
-                        StatisticElement.MOVING_TIME.name(),
-                        StatisticElement.DISTANCE_MI.name(),
-                        StatisticElement.PACE_MIN_MI.name(),
-                        StatisticElement.SPEED_MI_H.name(),
-                        StatisticElement.ELEVATION_GAIN_FEET.name(),
-                        StatisticElement.AVERAGE_SPEED_KM_H.name());
-            }
+        if (mRes.getConfiguration().getLocales().get(0).getCountry().equals("US")) {
+            Unit_Statistic_Elements = Set.of(
+                    StatisticElement.CATEGORY.name(),
+                    StatisticElement.MOVING_TIME.name(),
+                    StatisticElement.DISTANCE_KM.name(),
+                    StatisticElement.PACE_MIN_KM.name(),
+                    StatisticElement.SPEED_KM_H.name(),
+                    StatisticElement.ELEVATION_GAIN_METER.name(),
+                    StatisticElement.AVERAGE_SPEED_MI_H.name());
+        } else {
+            Unit_Statistic_Elements = Set.of(
+                    StatisticElement.CATEGORY.name(),
+                    StatisticElement.MOVING_TIME.name(),
+                    StatisticElement.DISTANCE_MI.name(),
+                    StatisticElement.PACE_MIN_MI.name(),
+                    StatisticElement.SPEED_MI_H.name(),
+                    StatisticElement.ELEVATION_GAIN_FEET.name(),
+                    StatisticElement.AVERAGE_SPEED_KM_H.name());
+        }
 
-            setStringSet(R.string.STATISTIC_ELEMENTS, Unit_Statistic_Elements);
+        setStringSet(R.string.STATISTIC_ELEMENTS, Unit_Statistic_Elements);
 
     }
 

--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/StatisticElement.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/StatisticElement.java
@@ -74,8 +74,13 @@ public enum StatisticElement {
     AVERAGE_SPEED_KM_H(R.string.average_speed_km_h) {
         @Override
         public String getText(Context context, TrackStatistics statistics) {
-            double avgSpeedMetersPerSecond = statistics.getAvgSpeedMeterPerSecond();
-            return String.valueOf(avgSpeedMetersPerSecond);
+            return StringUtils.formatSpeedInKmPerHour(context, statistics.getAvgSpeedMeterPerSecond());
+        }
+    },
+    AVERAGE_SPEED_MI_H(R.string.average_speed_mi_h) {
+        @Override
+        public String getText(Context context, TrackStatistics statistics) {
+            return StringUtils.formatSpeedInMiPerHour(context, statistics.getAvgSpeedMeterPerSecond());
         }
     };
 


### PR DESCRIPTION
## Description 

Resolved Issue #100 , Configured Statistics based on **Group 16**, for Imperial and Metrics. 
Used the Average Speed specified in the TrackStatistics.java.
Post using the Average speed, we format is accordingly (Either Metric Km/H or Imperial Mi/H) using StringUtils.java.
After that, added that in the PreferencesUtils.java.
