### PR TITLE
Group 12 saloni issue 113

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/DownloadActivity.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/DownloadActivity.java
@@ -405,5 +405,8 @@ public class DownloadActivity extends BaseActivity {
 
         public abstract ActivityResultLauncher<Intent> getLauncher(BaseActivity activity);
     }
-
+    @Override
+    protected void changeTypeOfMap(String s) {
+        // nothing to do
+    }
 }

--- a/src/main/java/de/storchp/opentracks/osmplugin/MainActivity.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/MainActivity.java
@@ -57,5 +57,10 @@ public class MainActivity extends BaseActivity {
     protected void onOnlineMapConsentChanged(boolean consent) {
         // nothing to do
     }
-
+    
+    @Override
+    protected void changeTypeOfMap(String s) {
+        // nothing to do
+    }
+    
 }


### PR DESCRIPTION
closes #113 
This pull request introduces a cool new addition in which I added a protected method to change the type of the image.
So, here's the deal with maps: due to the cash situation with APIs during our proof of concept, we've gone with static maps for the moment. But, hold on, because once we get our hands on that API, it's just a hop, skip, and a jump to dynamic maps. No worries, we're keeping the future in mind.

Quick heads up: to keep things rolling smoothly, we haven't swiped our credit cards for API credits from third-party providers. We're holding off on that spending spree for now.

Now, let's dive into the CustomImageLayer class – it's got a duo of methods, one for the image download hustle and the other for showing off the downloaded masterpiece. And to keep things interesting, we've tossed in a new method, changeTypeOfMap, to let you switch up the map vibes whenever you feel like it.

This implementation isn't just about the now; it's laying down the tracks for a future where our app can seamlessly dance with dynamic maps. Exciting times ahead!